### PR TITLE
craft 3.5 changes how it enables the debug bar

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^3.3.0",
+        "craftcms/cms": "^3.5.0",
         "sleiman/airtable-php": "^2.4"
     },
     "repositories": [

--- a/src/Module.php
+++ b/src/Module.php
@@ -64,7 +64,7 @@ class Module extends \yii\base\Module
             self::$_currentUser &&
             !Craft::$app->request->getIsConsoleRequest()
         ) {
-            Craft::$app->user->identity->mergePreferences([
+            self::$_currentUser->mergePreferences([
                 'enableDebugToolbarForSite' => true,
                 'enableDebugToolbarForCp' => true,
             ]);


### PR DESCRIPTION
Instead of reading from the session, it now reads from the user preferences to see if the debug bar should be shown

https://github.com/craftcms/cms/blob/128297aca238c0366892b9f22a3335ee14e68cec/src/web/Application.php#L399-L407

This also bumps the minimum requirements to craft 3.5