### PR TITLE
Phone home queue improvements

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -53,7 +53,7 @@ class Module extends \yii\base\Module
             $this->_bindCpEvents();
 
             // Phone home for Airtable inventory
-            if (!Craft::$app->request->getIsAjax()) {
+            if (!Craft::$app->request->getIsAjax() && Craft::$app->isInstalled) {
                 PhoneHome::makeCall();
             }
         }

--- a/src/services/PhoneHome.php
+++ b/src/services/PhoneHome.php
@@ -26,8 +26,8 @@ class PhoneHome
      */
     public static function makeCall()
     {
-        // We've checked recently enough, bail out
-        if (Craft::$app->cache->get(self::$_cacheKey) !== false) return;
+        // We've checked recently enough or a job in the queue already exists, bail out
+        if (Craft::$app->cache->get(self::$_cacheKey) !== false || self::_doesQueueJobExist()) return;
 
         Craft::$app->queue->push(new PhoneHomeJob());
     }
@@ -163,5 +163,15 @@ class PhoneHome
         }
 
         return implode(PHP_EOL, $modules);
+    }
+
+    /**
+     * Check if existing Phoning home job is already in the queue
+     *
+     * @return boolean
+     */
+    private static function _doesQueueJobExist(): bool
+    {
+        return array_search('Phoning home', array_column(Craft::$app->queue->jobInfo, 'description')) !== false;
     }
 }


### PR DESCRIPTION
* Check if Craft is installed before trying to phone home
* Don't add another phone home job to the queue if one already exists