### PR TITLE
protect against fatal error if using redis queue

### DIFF
--- a/src/services/PhoneHome.php
+++ b/src/services/PhoneHome.php
@@ -172,6 +172,9 @@ class PhoneHome
      */
     private static function _doesQueueJobExist(): bool
     {
+        // Potentially using the redis queue, so property doesn't exist
+        if (!Craft::$app->queue->hasProperty('jobInfo')) return false;
+
         return array_search('Phoning home', array_column(Craft::$app->queue->jobInfo, 'description')) !== false;
     }
 }


### PR DESCRIPTION
When using the Yii redis queue, the jobInfo property doesn't exist, so check if it exists to prevent error