### PR TITLE
[n/a] eliminate margin on content right when fullscreen

### DIFF
--- a/src/resources/css/parts-kit.css
+++ b/src/resources/css/parts-kit.css
@@ -45,6 +45,10 @@
     display: none;
 }
 
+.parts-kit__sidebar.hidden + .parts-kit__main {
+    margin-right: 0;
+}
+
 .parts-kit__sidebar * {
     font: inherit;
     font-size: 100%;


### PR DESCRIPTION
the main content well of the parts kit has a slight right margin that should be turned off in full-screen mode. i noticed this with the grid overlays, so ill use those to show the problem:

before:
![image](https://user-images.githubusercontent.com/5114665/108899727-c1d7b800-75e6-11eb-9e8c-192981069199.png)

after:
![image](https://user-images.githubusercontent.com/5114665/108899777-d025d400-75e6-11eb-84dd-b708c1d9b2f7.png)
