### PR TITLE
[n/a] fix sidebar styling for parts with long names

### DIFF
--- a/src/resources/css/parts-kit.css
+++ b/src/resources/css/parts-kit.css
@@ -67,6 +67,7 @@
 }
 
 .parts-kit__sidebar .flex {
+    align-items: flex-start;
     display: flex;
 }
 /* Search */
@@ -123,6 +124,7 @@
 
 .parts-kit__nav-button {
     padding: .25rem;
+    text-align: left;
     width: 100%;
 }
 
@@ -136,7 +138,9 @@
 .parts-kit__nav-story {
     display: block;
     fill: var(--pk-nav-icon);
+    flex-shrink: 0;
     margin-right: .25rem;
+    margin-top: .375rem;
     width: .625rem;
 }
 


### PR DESCRIPTION
Old:
![image](https://user-images.githubusercontent.com/5114665/113895954-7a247e80-9797-11eb-8e77-b797f47ca73f.png)


New:
![image](https://user-images.githubusercontent.com/5114665/113895894-6c6ef900-9797-11eb-9025-7f16d00d2ee1.png)
