### PR TITLE
Add GTM twig function

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -18,6 +18,7 @@ use viget\base\services\Util;
 use viget\base\services\PhoneHome;
 use viget\base\services\PartsKit;
 use viget\base\services\Tailwind;
+use viget\base\services\Tracking;
 
 /**
  * Yii Module for setting up custom Twig functionality to keep templates streamlined
@@ -91,6 +92,7 @@ class Module extends \yii\base\Module
             'util' => Util::class,
             'partsKit' => PartsKit::class,
             'tailwind' => Tailwind::class,
+            'tracking' => Tracking::class,
         ]);
     }
 

--- a/src/Module.php
+++ b/src/Module.php
@@ -62,7 +62,7 @@ class Module extends \yii\base\Module
             }
         }
 
-        // Always turn on the debug bar in dev environment (for logged in users)
+        // Always turn on the debug bar and field handles in dev environment (for logged in users)
         if (
             getenv('ENVIRONMENT') === 'dev' &&
             self::$_currentUser &&
@@ -71,6 +71,7 @@ class Module extends \yii\base\Module
             self::$_currentUser->mergePreferences([
                 'enableDebugToolbarForSite' => true,
                 'enableDebugToolbarForCp' => true,
+                'showFieldHandles' => true,
             ]);
         }
 

--- a/src/services/Tracking.php
+++ b/src/services/Tracking.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace viget\base\services;
+
+use Craft;
+use craft\helpers\Html;
+use craft\helpers\ArrayHelper;
+
+/**
+ * Helper class for formatting GTM data attributes
+ */
+class Tracking
+{
+    /**
+     * Return attributes for tracking imploded with a pipe
+     *
+     * @param Array|string ...$params
+     * @return string
+     */
+    public static function getGtmAttribute(...$params): string
+    {
+        $attrs = [];
+
+        foreach ($params as $param) {
+            if (is_array($param)) {
+                ArrayHelper::append($attrs, ...$param);
+            } else {
+                ArrayHelper::append($attrs, $param);
+            }
+        }
+
+        return Html::encode(implode('|', array_filter($attrs)));
+    }
+}

--- a/src/twigextensions/Extension.php
+++ b/src/twigextensions/Extension.php
@@ -6,6 +6,7 @@ use Craft;
 use Twig\TwigFunction;
 use Twig\Extension\AbstractExtension;
 use viget\base\services\PartialLoader;
+use viget\base\services\Tracking;
 
 /**
  * Custom Twig Extensions
@@ -22,9 +23,28 @@ class Extension extends AbstractExtension
         return [
             new TwigFunction(
                 'partial',
-                [PartialLoader::class, 'load'],
-                ['is_safe' => ['html']]
+                [
+                    PartialLoader::class,
+                    'load',
+                ],
+                [
+                    'is_safe' => [
+                        'html',
+                    ],
+                ]
             ),
+            new TwigFunction(
+                'gtm',
+                [
+                    Tracking::class,
+                    'getGtmAttribute',
+                ],
+                [
+                    'is_safe' => [
+                        'html',
+                    ]
+                ]
+            )
         ];
     }
 }

--- a/tests/_craft/templates/tracking-test.html
+++ b/tests/_craft/templates/tracking-test.html
@@ -1,0 +1,21 @@
+<div data-track-gtm="{{ gtm('Basic String', 'tracking', 'attributes') }}"></div>
+<div data-track-gtm="{{ gtm('"Basic String"', 'with', 'quote') }}"></div>
+<div data-track-gtm="{{ gtm(['"Basic Array"', 'with', 'quote']) }}"></div>
+
+<div
+    {{ attr({
+        'data-track-gtm': gtm('Attr String', 'tracking', 'attributes'),
+    }) }}
+></div>
+
+<div
+    {{ attr({
+        'data-track-gtm': gtm('"Attr String"', 'with', 'quote'),
+    }) }}
+></div>
+
+<div
+    {{ attr({
+        'data-track-gtm': gtm(['"Attr Array"', 'with', 'quote']),
+    }) }}
+></div>

--- a/tests/functional/TrackingCest.php
+++ b/tests/functional/TrackingCest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace vigetbasetests\functional;
+
+use FunctionalTester;
+
+class TrackingCest
+{
+    public function testTrack(FunctionalTester $I)
+    {
+        $I->amOnPage('/tracking-test');
+        $I->seeInSource('Basic String|tracking|attributes');
+        $I->seeInSource('&quot;Basic String&quot;|with|quote');
+        $I->seeInSource('&quot;Basic Array&quot;|with|quote');
+    }
+
+    public function testAttrTrack(FunctionalTester $I)
+    {
+        $I->amOnPage('/tracking-test');
+        $I->seeInSource('Attr String|tracking|attributes');
+        $I->seeInSource('&amp;quot;Attr String&amp;quot;|with|quote');
+        $I->seeInSource('&amp;quot;Attr Array&amp;quot;|with|quote');
+    }
+}

--- a/tests/unit/TrackingTest.php
+++ b/tests/unit/TrackingTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace vigetbasetests\unit;
+
+use Codeception\Test\Unit;
+use UnitTester;
+
+use viget\base\Module;
+
+class TrackingTest extends Unit
+{
+    /**
+     * @var UnitTester
+     */
+    protected $tester;
+
+    public function testGtmStrings()
+    {
+        $this->assertEquals(
+            'one|two|three',
+            Module::$instance->tracking->getGtmAttribute('one', 'two', 'three')
+        );
+        $this->assertEquals(
+            '&quot;one&quot;|two|three',
+            Module::$instance->tracking->getGtmAttribute('"one"', 'two', 'three')
+        );
+    }
+
+    public function testGtmArray()
+    {
+        $this->assertEquals(
+            'one|two|three',
+            Module::$instance->tracking->getGtmAttribute([
+                'one',
+                'two',
+                'three',
+            ])
+        );
+
+        $this->assertEquals(
+            '&quot;one&quot;|two|three',
+            Module::$instance->tracking->getGtmAttribute([
+                '"one"',
+                'two',
+                'three',
+            ])
+        );
+    }
+}


### PR DESCRIPTION
Added a new `gtm()` twig function, you can either pass string params or an array

```twig
gtm('one', 'two')
```

```twig
gtm(['one', 'two'])
```

Added tests for that functionality

Also turned on field handles when in dev environment
