### PR TITLE
[#40] disable turbo to fix issues

### DIFF
--- a/src/templates/_layouts/parts-kit.html
+++ b/src/templates/_layouts/parts-kit.html
@@ -7,7 +7,7 @@
         }
     </style>
 
-    <div class="parts-kit" data-parts-kit>
+    <div class="parts-kit" data-parts-kit data-turbo="false">
         <aside
             class="parts-kit__sidebar"
             data-sidebar


### PR DESCRIPTION
Sites using Turbo are not compatible with the current structure of the JS in the parts kit. While we could go down a route of configuration or detection to adjust how the parts kit is initialized (e.g. wrapping that in a listener for `turbo:loaded`), it seems to me that it's adding a bunch of code for little pay off. Disabling turbo is a quick and simple fix.