### PR TITLE
Redirect parts kit index request to first component

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,10 +15,9 @@ services:
     expose:
       - 9000
     volumes:
-      - .:/var/www/html
-      - composer:/var/www/html/vendor
-      - runtime:/var/www/html/storage/runtime
-      - logs:/var/www/html/storage/logs
+      - .:/var/www/html:cached
+      - ./vendor:/var/www/html/vendor:delegated
+      - ./storage/logs:/var/www/html/storage/logs:delegated
     environment:
       - ENVIRONMENT=dev
       - DB_DSN=mysql:host=mysql;port=3306;dbname=craft_base_test
@@ -42,6 +41,3 @@ services:
 
 volumes:
   db:
-  composer:
-  runtime:
-  logs:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,7 +12,7 @@ composer require viget/craft-viget-base
 
 Lock it at a specific version if desired.
 
-Open the `config/app.php` and add the bootstrap the module (merging with existing modules if they exist):
+Open the `config/app.php` and bootstrap the module (merging with existing modules if they exist):
 
 ```php
 <?php

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,32 +6,30 @@ nav_order: 1
 
 # Installation
 
-## If you do not have an existing module
-
-Use the [Craft Starter Module](https://github.com/vigetlabs/craft-starter-module)
-
-## If you have an existing module
-
 ```
 composer require viget/craft-viget-base
 ```
 
 Lock it at a specific version if desired.
 
-Open the main `Module` class that you want to use. At the top of your `init` method, add the following:
+Open the `config/app.php` and add the bootstrap the module (merging with existing modules if they exist):
 
 ```php
-// Initialize all the viget base code
-$this->setModules([
-    'viget-base' => [
-        'class' => '\viget\base\Module',
-    ],
-]);
+<?php
 
-$this->getModule('viget-base');
+return [
+    'modules' => [
+        'viget-base' => [
+            'class' => \viget\base\Module::class,
+        ],
+    ],
+    'bootstrap' => [
+        'viget-base',
+    ],
+];
 ```
 
-### Configure Phone Home
+## Configure Phone Home
 
 Add the following ENV variables to your enviroment file in all environments
 

--- a/src/Module.php
+++ b/src/Module.php
@@ -51,7 +51,7 @@ class Module extends \yii\base\Module
             Craft::$app->view->registerTwigExtension(new Extension());
 
             if (!Craft::$app->request->getIsAjax() && !Craft::$app->request->getIsConsoleRequest()) {
-                $this->view->registerAssetBundle(Bundle::class);
+                Craft::$app->view->registerAssetBundle(Bundle::class);
             }
         }
 
@@ -161,7 +161,7 @@ class Module extends \yii\base\Module
                 function (RegisterUrlRulesEvent $event) {
                     $partsKitDir = self::$config['partsKit']['directory'];
 
-                    $event->rules[$partsKitDir] = ['template' => 'viget-base/parts-kit/index'];
+                    $event->rules[$partsKitDir] = 'viget-base/parts-kit/redirect-index';
                 }
             );
         }

--- a/src/Module.php
+++ b/src/Module.php
@@ -6,6 +6,8 @@ use Craft;
 use yii\base\Event;
 use craft\events\RegisterCpNavItemsEvent;
 use craft\events\RegisterTemplateRootsEvent;
+use craft\events\RegisterUrlRulesEvent;
+use craft\web\UrlManager;
 use craft\web\twig\variables\Cp;
 use craft\web\View;
 use craft\web\twig\variables\CraftVariable;
@@ -141,8 +143,8 @@ class Module extends \yii\base\Module
             }
         );
 
-        // Define viget base templates directory
-        if (PartsKit::isRequest()) {
+        // Define viget base templates directory and index url
+        if (self::$instance->partsKit->isRequest()) {
             Event::on(
                 View::class,
                 View::EVENT_REGISTER_SITE_TEMPLATE_ROOTS,
@@ -150,6 +152,16 @@ class Module extends \yii\base\Module
                     if (is_dir($baseDir = __DIR__ . DIRECTORY_SEPARATOR . 'templates')) {
                         $e->roots['viget-base'] = $baseDir;
                     }
+                }
+            );
+
+            Event::on(
+                UrlManager::class,
+                UrlManager::EVENT_REGISTER_SITE_URL_RULES,
+                function (RegisterUrlRulesEvent $event) {
+                    $partsKitDir = self::$config['partsKit']['directory'];
+
+                    $event->rules[$partsKitDir] = ['template' => 'viget-base/parts-kit/index'];
                 }
             );
         }

--- a/src/controllers/PartsKitController.php
+++ b/src/controllers/PartsKitController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace viget\base\controllers;
+
+use yii\web\Response;
+
+use viget\base\Module;
+
+class PartsKitController extends \craft\web\Controller
+{
+    protected $allowAnonymous = true;
+
+    /**
+     * Redirect to the first component in the parts kit
+     *
+     * @return Response
+     */
+    public function actionRedirectIndex(): Response
+    {
+        $redirectUrl = Module::$instance->partsKit->getFirstNavUrl();
+
+        if (!$redirectUrl) {
+            throw new \Exception('Looks like you don’t have any parts kit components setup yet.');
+        }
+
+        return $this->redirect($redirectUrl, 301);
+    }
+}

--- a/src/services/PartsKit.php
+++ b/src/services/PartsKit.php
@@ -7,6 +7,7 @@ use craft\helpers\StringHelper;
 use craft\helpers\FileHelper;
 use craft\helpers\UrlHelper;
 use craft\helpers\Template as TemplateHelper;
+use craft\helpers\ArrayHelper;
 use craft\elements\Asset;
 use Twig\Markup;
 
@@ -41,15 +42,15 @@ class PartsKit
     /**
      * Get navigation of files/folders in parts kit
      *
-     * @return array|null
+     * @return array
      */
-    public static function getNav(): ?array
+    public static function getNav(): array
     {
         $partsKitDir = self::getConfig('directory');
 
         $templates = self::_getTemplates($partsKitDir);
 
-        if (empty($templates)) return null;
+        if (empty($templates)) return [];
 
         $items = [];
 
@@ -85,6 +86,21 @@ class PartsKit
         }
 
         return $items;
+    }
+
+    /**
+     * Get the first component's URL
+     *
+     * @return string|null
+     */
+    public static function getFirstNavUrl(): ?string
+    {
+        $nav = self::getNav();
+        $firstUrl = ArrayHelper::firstValue($nav)['items'][0]['url'] ?? null;
+
+        if (!$firstUrl) return null;
+
+        return parse_url($firstUrl)['path'];
     }
 
     /**

--- a/src/templates/parts-kit/index.html
+++ b/src/templates/parts-kit/index.html
@@ -1,6 +1,0 @@
-{% set redirectUrl = craft.viget.partsKit.getFirstNavUrl %}
-{% if redirectUrl %}
-    {% redirect redirectUrl 301 %}
-{% endif %}
-
-Looks like you don’t have any parts kit components setup yet. Refer to <a href="http://code.viget.com/craft-viget-base/parts-kit.html">the documentation</a> if you need any help.

--- a/src/templates/parts-kit/index.html
+++ b/src/templates/parts-kit/index.html
@@ -1,0 +1,8 @@
+{% set redirectUrl = craft.viget.partsKit.getFirstNavUrl %}
+{% if redirectUrl %}
+    {% redirect redirectUrl 301 %}
+{% endif %}
+
+{{ redirectUrl }}
+
+Looks like you don’t have any parts kit components setup yet. Refer to <a href="http://code.viget.com/craft-viget-base/parts-kit.html">the documentation</a> if you need any help.

--- a/src/templates/parts-kit/index.html
+++ b/src/templates/parts-kit/index.html
@@ -3,6 +3,4 @@
     {% redirect redirectUrl 301 %}
 {% endif %}
 
-{{ redirectUrl }}
-
 Looks like you don’t have any parts kit components setup yet. Refer to <a href="http://code.viget.com/craft-viget-base/parts-kit.html">the documentation</a> if you need any help.

--- a/tests/_craft/templates/parts-kit/index.html
+++ b/tests/_craft/templates/parts-kit/index.html
@@ -1,5 +1,0 @@
-{% extends 'viget-base/_layouts/parts-kit' %}
-
-{% block main %}
-    Parts kit index
-{% endblock %}

--- a/tests/functional/PartsKitCest.php
+++ b/tests/functional/PartsKitCest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace vigetbasetests\functional;
+
+use FunctionalTester;
+
+class PartsKitCest
+{
+    public function testIndexRedirect(FunctionalTester $I)
+    {
+        $I->amOnPage('/parts-kit');
+        $I->seeCurrentUrlEquals('/parts-kit/button/blue');
+    }
+}

--- a/tests/unit/PartsKitTest.php
+++ b/tests/unit/PartsKitTest.php
@@ -79,4 +79,11 @@ class PartsKitTest extends Unit
 
         $this->assertInstanceOf('craft\elements\Asset', $image);
     }
+
+    public function testGetFirstNavUrl()
+    {
+        Craft::$app->request->setUrl('/parts-kit');
+
+        $this->assertEquals('/parts-kit/button/blue', Module::$instance->partsKit->getFirstNavUrl());
+    }
 }


### PR DESCRIPTION
Instead of forcing everyone to add a `parts-kit/index.html` file that basically does nothing, automatically redirect to the first component like Storybook does.

Also adjusted the docker setup so the vendor folder is available locally