### PR TITLE
[#44] Restrict `f` key shortcut to `f` key only

### DIFF
--- a/src/resources/js/parts-kit.js
+++ b/src/resources/js/parts-kit.js
@@ -173,17 +173,23 @@ class PartsKit {
         })
     }
 
-    noUserInput = () => document.activeElement.tagName !== 'INPUT'
+    hasUserInput = () => document.activeElement.tagName === 'INPUT'
 
-    handleKeydown = ({ key }) => {
-        if ((key === "f" || key === "Escape") && this.noUserInput()) {
+    handleKeydown = ({key, metaKey, ctrlKey}) => {
+        const hasModifier = metaKey || ctrlKey
+
+        // Short circuit if a user is typing in an input or pressing a modifying key
+        if (this.hasUserInput() || hasModifier) {
+            return;
+        }
+
+        if (['f', 'Escape'].includes(key)) {
             this.toggleSidebar();
         }
 
-        if(key === "/" && this.noUserInput()) {
+        if (key === "/") {
             this.focusOnSearch();
         }
-
     };
 
     focusOnSearch() {


### PR DESCRIPTION
This tweak prevents our keyboard functions from firing if `CTRL` or `CMD` is being pressed. 

https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#properties