### PR TITLE
parts kit style polish

### DIFF
--- a/src/resources/css/parts-kit.css
+++ b/src/resources/css/parts-kit.css
@@ -203,7 +203,6 @@
     color: var(--pk-controls-text);
     display: flex;
     justify-content: flex-end;
-    margin-bottom: .75rem;
     padding: .375rem .75rem;
 }
 

--- a/src/resources/css/parts-kit.css
+++ b/src/resources/css/parts-kit.css
@@ -221,7 +221,7 @@
     background: var(--pk-main-background);
     border-radius: .25rem;
     box-shadow: 0 10px 18px rgba(0, 0, 0, 0.25);
-    height: 100%;
+    height: auto;
 }
 
 .parts-kit__main-container {

--- a/src/resources/css/parts-kit.css
+++ b/src/resources/css/parts-kit.css
@@ -36,8 +36,11 @@
     color: var(--pk-text);
     flex-shrink: 0;
     font-family: BlinkMacSystemFont, sans-serif;
-    min-height: 100vh;
+    height: 100vh;
+    overflow-y: auto;
     padding: 2rem 0 .75rem;
+    position: sticky;
+    top: 0;
     width: 210px;
 }
 


### PR DESCRIPTION
Adjustments made for lessons learned on recent Viget projects

- enhancement: the main panel is only as tall as the component, instead of stretching to fill the window. in theory this could help catch unexpected bottom padding
- fixed: there isn’t always vertical overflow
- the sidebar sticks to the top of the window and has its own scrollbar 