### PR TITLE
Fix duplicate bootstrapping

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -32,12 +32,6 @@ class Module extends \yii\base\Module implements BootstrapInterface
 {
     public static $config;
 
-    public function init()
-    {
-        parent::init();
-        $this->bootstrap(Craft::$app);
-    }
-
     public function bootstrap($app)
     {
         Craft::setAlias('@viget/base', __DIR__);


### PR DESCRIPTION
A Yii auto-bootstraped module automatically calls the `bootstrap` method.

We we're explicitly calling the bootstrap method which was resulting in everything in the module running twice. For example, outputting the custom navigation items twice.

Since the only other thing in our `init` method was to call the parent `init`, the whole method can be removed

Ref: https://www.yiiframework.com/doc/guide/2.0/en/structure-extensions#bootstrapping-classes