### PR TITLE
[#66] Adds collections support in `Util::fillInEntries()`

### DIFF
--- a/src/services/Util.php
+++ b/src/services/Util.php
@@ -4,6 +4,7 @@ namespace viget\base\services;
 
 use Craft;
 use craft\elements\Entry;
+use Illuminate\Support\Collection;
 
 /**
  * Various utility services that can be accessed by Twig
@@ -14,7 +15,7 @@ class Util
     * Query for additional, deduped entries to a fill a number
     * of needed entries
     *
-    * @param array $entries
+    * @param array|Collection $entries
     * @param array $params
     * @param int $limit
     * @param array $additionalIdsToSkip
@@ -22,12 +23,16 @@ class Util
     * @return array
     */
     public static function fillInEntries(
-        array $entries = [],
+        array|Collection $entries = [],
         array $params = [],
         int $limit = 0,
         array $additionalIdsToSkip = []
     ): array
     {
+        if ($entries instanceof Collection) {
+            $entries = $entries->all();
+        }
+
         if (!$limit) return [];
 
         $entriesNeeded = $limit - count($entries);


### PR DESCRIPTION
Util::fillInEntries() expects an array of entries. However, with Craft 4 going all in on Collections, it probably makes sense to support that type as well.

**Context:**

Ran into a lot of uses for this method on HRC's Craft 4 upgrade. Since eager loading returns collections, I figured it made more sense to just have our function embrace collections rather than change all uses of this function on HRC. 

Curious y'alls thoughts