### PR TITLE
[#69] Add `disableEditButton` option to module config

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -130,6 +130,12 @@ class Module extends \yii\base\Module implements BootstrapInterface
             View::EVENT_END_BODY,
             static function (Event $e) {
                 if (
+                    self::$config['disableEditButton']
+                ) {
+                    return;
+                }
+
+                if (
                     Craft::$app->config->general->devMode ||
                     Craft::$app->user->checkPermission('accessCp')
                 ) {
@@ -219,6 +225,7 @@ class Module extends \yii\base\Module implements BootstrapInterface
             'tailwind' => [
                 'configPath' => Craft::getAlias('@config/tailwind/tailwind.json'),
             ],
+            'disableEditButton' => false,
         ];
 
         $userSettings = Craft::$app->config->getConfigFromFile('viget');


### PR DESCRIPTION
- #69

----

Add a `disableEditButton` configuration option and check that when deciding whether or not to output an `Edit Entry` button on the front-end.

This allows us to set a value in `config/viget.php` to bypass the built-in logic.