### PR TITLE
[#69] Update readme for `disableEditButton`

### DIFF
--- a/docs/extras.md
+++ b/docs/extras.md
@@ -17,3 +17,15 @@ Custom field handles on CP edit forms will be visible in the dev enviroment.
 ## Front-end edit entry Links
 
 When visiting an element URL on the front-end, an edit entry link to edit that element in the CP will be present in the lower left hand corner. This will always be present in the dev environment regardless of logged-in state or permissions.
+
+In order to prevent these links from being cached by Blitz (or simply to remove it from any site), `^v5.0.4` adds a boolean `disableEditButton` option to the module config which prevents the `Edit Entry` links from being output. The default value is `false` but can be changed in a project’s `config/viget.php` to `true` or `!App::devMode()`:
+
+```php
+<?php
+
+use craft\helpers\App;
+
+return [
+    'disableEditButton' => !App::devMode(), // default is false
+];
+```


### PR DESCRIPTION
- #69 
- https://github.com/vigetlabs/craft-viget-base/pull/70#issuecomment-1782987824

----

Updates the readme to explain the new `disableEditButton` config option and how to apply it.