### PR TITLE
[#79] Alphabetic sorting of parts kit nav.

### DIFF
--- a/src/services/PartsKit.php
+++ b/src/services/PartsKit.php
@@ -112,7 +112,7 @@ class PartsKit
                 continue;
             }
 
-            $parentNode->children[] = $node;
+            array_unshift($parentNode->children, $node);
             unset($result[$node->path]);
         }
 


### PR DESCRIPTION
### Overview

I noticed that child nav items on the new parts kit were sorted backwards.

**Before**
![image](https://github.com/vigetlabs/craft-viget-base/assets/2145998/44a138cf-fb91-4008-b27a-29dfc0281259)


**After**
![image](https://github.com/vigetlabs/craft-viget-base/assets/2145998/eb70a8ef-e649-4980-9efb-8fa3ff392621)
