### PR TITLE
[N/A] Ignore files prefixed with underscore

### DIFF
--- a/src/services/PartsKit.php
+++ b/src/services/PartsKit.php
@@ -87,7 +87,13 @@ class PartsKit
 
             $path = str_replace($partsPath, '', $templatePath);
             $pathParts = explode('/', $path);
-            $title = self::_formatTitle(end($pathParts));
+            $lastPart = end($pathParts);
+
+            if(str_starts_with($lastPart, '_')) {
+                continue;
+            }
+
+            $title = self::_formatTitle($lastPart);
             $url = is_file($templatePath)
                 ? '/' . $partsKitFolderName . '/' . self::_removeExtension($path)
                 : null;


### PR DESCRIPTION
# Summary

This PR filters files from the Parts Kit that begin with an underscore.

## Issues

* N/A

## Testing Instructions

1. Add a file to the parts-kit directory that begins with an `_` (underscore)
2. The file should not be present in the Parts Kit navigation